### PR TITLE
Makes Windows-encoded .css files work; warns about Rhino version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>lesscss-engine</artifactId>
     <packaging>jar</packaging>
     <name>LESS Engine</name>
-    <version>1.0.41</version>
+    <version>1.1.42</version>
     <description>A Java wrapper for LESS (http://lesscss.org). LESS extends CSS with: variables, mixins, operations and nested rules.</description>
     <url>http://www.asual.com/lesscss</url>
     

--- a/src/main/java/com/asual/lesscss/LessEngine.java
+++ b/src/main/java/com/asual/lesscss/LessEngine.java
@@ -54,6 +54,7 @@ public class LessEngine {
 			URL less = getClass().getClassLoader().getResource("META-INF/less.js");
 			URL engine = getClass().getClassLoader().getResource("META-INF/engine.js");
 			Context cx = Context.enter();
+            logger.warn("Using implementation version: " + cx.getImplementationVersion());
 			cx.setOptimizationLevel(9);
 			Global global = new Global();
 			global.init(cx);		  
@@ -83,6 +84,7 @@ public class LessEngine {
 	public String compile(URL input) throws LessException {
 		try {
 			long time = System.currentTimeMillis();
+            logger.debug("Compiling URL: " + input.getProtocol() + ":" + input.getFile());
 			String result = call(cf, new Object[] {input.getProtocol() + ":" + input.getFile(), getClass().getClassLoader()});
 			logger.debug("The compilation of '" + input + "' took " + (System.currentTimeMillis () - time) + " ms.");
 			return result;
@@ -94,6 +96,7 @@ public class LessEngine {
 	public String compile(File input) throws LessException {
 		try {
 			long time = System.currentTimeMillis();
+            logger.debug("Compiling File: " + "file:" + input.getAbsolutePath());
 			String result = call(cf, new Object[] {"file:" + input.getAbsolutePath(), getClass().getClassLoader()});
 			logger.debug("The compilation of '" + input + "' took " + (System.currentTimeMillis () - time) + " ms.");
 			return result;

--- a/src/main/resources/META-INF/engine.js
+++ b/src/main/resources/META-INF/engine.js
@@ -16,13 +16,13 @@ var compileFile = function(file, classLoader) {
         } else if (path.substr(0, 1) != '/') {
             path = dirname + path;
         }
-        new(window.less.Parser)({ optimization: 3 }).parse(readUrl(path, charset), function (e, root) {
+        new(window.less.Parser)({ optimization: 3 }).parse(readUrl(path, charset).replace(/\r/g, ''), function (e, root) {
             fn(root);
             if (e instanceof Object)
                 throw e;
         });
     };
-    new(window.less.Parser)({ optimization: 3 }).parse(readUrl(file, charset), function (e, root) {
+    new(window.less.Parser)({ optimization: 3 }).parse(readUrl(file, charset).replace(/\r/g, ''), function (e, root) {
         result = root.toCSS();
         if (e instanceof Object)
             throw e;


### PR DESCRIPTION
1) This makes CSS with Windows line-ending (\r) work. Probably not the best way to do it, since readUrl() seems to be a Rhino "shell tools" built-in.
2) This logs a WARN about the Rhino implementation version. I banged my head against this for a few hours before realizing that some other dependency in my pom was pulling an older version of rhino. I wonder about Maven dependency resolution, but the 1.6R7 version in lesscss's POM is not respected. This WARN makes it easier to spot, during servlet init()
