### PR TITLE
Fix a bug with @import subfolder/blabla.less

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>rhino</groupId>
             <artifactId>js</artifactId>
-            <version>1.6R7</version>
+            <version>1.7R2</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.7</version>
+            <version>4.8.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -106,6 +106,7 @@
                 <includes>
                     <include>log4j.xml</include>
                     <include>**/*.css</include>
+                    <include>**/*.less</include>
                 </includes>
             </testResource>
         </testResources>

--- a/src/main/java/com/asual/lesscss/LessEngine.java
+++ b/src/main/java/com/asual/lesscss/LessEngine.java
@@ -85,6 +85,7 @@ public class LessEngine {
 		try {
 			long time = System.currentTimeMillis();
             logger.debug("Compiling URL: " + input.getProtocol() + ":" + input.getFile());
+            logger.info(input.getProtocol() + ":" + input.getFile());
 			String result = call(cf, new Object[] {input.getProtocol() + ":" + input.getFile(), getClass().getClassLoader()});
 			logger.debug("The compilation of '" + input + "' took " + (System.currentTimeMillis () - time) + " ms.");
 			return result;

--- a/src/main/resources/META-INF/engine.js
+++ b/src/main/resources/META-INF/engine.js
@@ -5,7 +5,7 @@ var compileString = function(css) {
             if (e instanceof Object)
                 throw e;
     });
-    return result;    
+    return result;
 };
 
 var compileFile = function(file, classLoader) {
@@ -14,15 +14,15 @@ var compileFile = function(file, classLoader) {
         if (path.indexOf(cp) == 0) {
             path = classLoader.getResource(path.replace(cp, ''));
         } else if (path.substr(0, 1) != '/') {
-            path = dirname + path;
+            path = paths[0] + path;
         }
-        new(window.less.Parser)({ optimization: 3 }).parse(readUrl(path, charset).replace(/\r/g, ''), function (e, root) {
+        new(window.less.Parser)({ optimization: 3, paths: [String(path).replace(/[\w\.-]+$/, '')] }).parse(readUrl(path, charset).replace(/\r/g, ''), function (e, root) {
             fn(root);
             if (e instanceof Object)
                 throw e;
         });
     };
-    new(window.less.Parser)({ optimization: 3 }).parse(readUrl(file, charset).replace(/\r/g, ''), function (e, root) {
+    new(window.less.Parser)({ optimization: 3, paths: [file.replace(/[\w\.-]+$/, '')] }).parse(readUrl(file, charset).replace(/\r/g, ''), function (e, root) {
         result = root.toCSS();
         if (e instanceof Object)
             throw e;

--- a/src/test/java/com/asual/lesscss/LessEngineTest.java
+++ b/src/test/java/com/asual/lesscss/LessEngineTest.java
@@ -36,100 +36,107 @@ import org.junit.Test;
  * @author Eliot Sykes
  */
 public class LessEngineTest {
-	
-	private static LessEngine engine;
-	
-	@BeforeClass
-	public static void before() {
-		engine = new LessEngine();
-	}
-	
-	@Test
-	public void parse() throws LessException {
-		assertEquals("div {\n  width: 2;\n}\n", engine.compile("div { width: 1 + 1 }"));
-	}
-	
-	@Test
-	public void compileToString() throws LessException, IOException {
-		assertEquals("body {\n  color: #f0f0f0;\n}\n", 
-				engine.compile(getUrl("test.css")));
-	}
-	
-	@Test
-	public void compileToFile() throws LessException, IOException {
-		File tempDir = new File(System.getProperty("java.io.tmpdir"));
-		File tempFile = File.createTempFile("less.css", null, tempDir);
-		engine.compile(
-				new File(getUrl("test.css").getPath()),
-				new File(tempFile.getAbsolutePath()));
-		FileInputStream fstream = new FileInputStream(tempFile.getAbsolutePath());
-		DataInputStream in = new DataInputStream(fstream);
-		BufferedReader br = new BufferedReader(new InputStreamReader(in));
-		String strLine;
-		StringBuilder sb = new StringBuilder();
-		while ((strLine = br.readLine()) != null) {
-			sb.append(strLine);
-		}
-		in.close();
-		assertEquals("body {  color: #f0f0f0;}", sb.toString());
-		tempFile.delete();
-	}
 
-	@Test
-	public void compileToStringForMultipleImports() throws LessException, IOException {
-		String expected = "body {\n" +
-				"  font-family: Arial, Helvetica;\n" +
-				"}\n" +
-				"body {\n" +
-				"  width: 960px;\n" +
-				"  margin: 0;\n" +
-				"}\n" +
-				"#header {\n" +
-				"  border-radius: 5px;\n" +
-				"  -webkit-border-radius: 5px;\n" +
-				"  -moz-border-radius: 5px;\n" +
-				"}\n" +
-				"#footer {\n" +
-				"  border-radius: 10px;\n" +
-				"  -webkit-border-radius: 10px;\n" +
-				"  -moz-border-radius: 10px;\n" +
-				"}\n";
-		assertEquals(expected, engine.compile(getUrl("multiple-imports.css")));
-	}
-	
-	@Test(expected = LessException.class)
-	public void testUndefinedErrorInput() throws IOException, LessException {
-		try {
-			engine.compile(getUrl("undefined-error.css"));
-		} catch (LessException e) {
-			assertTrue("is undefined error", e.getMessage().contains("Error: .bgColor is undefined (line 2, column 4)"));
-			throw e;
-		}
-		
-	}
- 
-	@Test(expected = LessException.class)
-	public void testSyntaxErrorInput() throws IOException, LessException {
-		try {
-			engine.compile(getUrl("syntax-error.css"));
-		} catch (LessException e) {
-			assertTrue("is syntax error", e.getMessage().contains("Syntax Error: Missing closing `}` (line -1, column -1)"));
-			throw e;
-		}
-	}
-	
-	@Test(expected = LessException.class)
-	public void testParseErrorInput() throws IOException, LessException {
-		try {
-			engine.compile(getUrl("parse-error.css"));
-		} catch (LessException e) {
-			assertTrue("is parse error", e.getMessage().contains("Parse Error: Syntax Error on line 2"));
-			throw e;
-		}
-	}
-	
-	private URL getUrl(String filename) {
-		return getClass().getClassLoader().getResource("META-INF/" + filename);
-	}
+    private static LessEngine engine;
+
+    @BeforeClass
+    public static void before() {
+        engine = new LessEngine();
+    }
+
+    @Test
+    public void parse() throws LessException {
+        assertEquals("div {\n  width: 2;\n}\n", engine.compile("div { width: 1 + 1 }"));
+    }
+
+    @Test
+    public void compileToString() throws LessException, IOException {
+        assertEquals("body {\n  color: #f0f0f0;\n}\n",
+                engine.compile(getUrl("test.css")));
+    }
+
+    @Test
+    public void compileToFile() throws LessException, IOException {
+        File tempDir = new File(System.getProperty("java.io.tmpdir"));
+        File tempFile = File.createTempFile("less.css", null, tempDir);
+        engine.compile(
+                new File(getUrl("test.css").getPath()),
+                new File(tempFile.getAbsolutePath()));
+        FileInputStream fstream = new FileInputStream(tempFile.getAbsolutePath());
+        DataInputStream in = new DataInputStream(fstream);
+        BufferedReader br = new BufferedReader(new InputStreamReader(in));
+        String strLine;
+        StringBuilder sb = new StringBuilder();
+        while ((strLine = br.readLine()) != null) {
+            sb.append(strLine);
+        }
+        in.close();
+        assertEquals("body {  color: #f0f0f0;}", sb.toString());
+        tempFile.delete();
+    }
+
+    @Test
+    public void compileToStringForMultipleImports() throws LessException, IOException {
+        String expected = "body {\n" +
+                "  font-family: Arial, Helvetica;\n" +
+                "}\n" +
+                "body {\n" +
+                "  width: 960px;\n" +
+                "  margin: 0;\n" +
+                "}\n" +
+                "#header {\n" +
+                "  border-radius: 5px;\n" +
+                "  -webkit-border-radius: 5px;\n" +
+                "  -moz-border-radius: 5px;\n" +
+                "}\n" +
+                "#footer {\n" +
+                "  border-radius: 10px;\n" +
+                "  -webkit-border-radius: 10px;\n" +
+                "  -moz-border-radius: 10px;\n" +
+                "}\n";
+        assertEquals(expected, engine.compile(getUrl("multiple-imports.css")));
+    }
+
+    @Test
+    public void compileSubdirImports() throws LessException, IOException {
+        engine.compile(getUrl("root.less"));
+        engine.compile(getUrl("subdir/import-from-root.less"));
+        engine.compile(getUrl("import-from-subdir.less"));
+    }
+
+    @Test(expected = LessException.class)
+    public void testUndefinedErrorInput() throws IOException, LessException {
+        try {
+            engine.compile(getUrl("undefined-error.css"));
+        } catch (LessException e) {
+            assertTrue("is undefined error", e.getMessage().contains("Error: .bgColor is undefined (line 2, column 4)"));
+            throw e;
+        }
+
+    }
+
+    @Test(expected = LessException.class)
+    public void testSyntaxErrorInput() throws IOException, LessException {
+        try {
+            engine.compile(getUrl("syntax-error.css"));
+        } catch (LessException e) {
+            assertTrue("is syntax error", e.getMessage().contains("Syntax Error: Missing closing `}` (line -1, column -1)"));
+            throw e;
+        }
+    }
+
+    @Test(expected = LessException.class)
+    public void testParseErrorInput() throws IOException, LessException {
+        try {
+            engine.compile(getUrl("parse-error.css"));
+        } catch (LessException e) {
+            assertTrue("is parse error", e.getMessage().contains("Parse Error: Syntax Error on line 2"));
+            throw e;
+        }
+    }
+
+    private URL getUrl(String filename) {
+        return getClass().getClassLoader().getResource("META-INF/" + filename);
+    }
 
 }

--- a/src/test/resources/META-INF/import-from-subdir.less
+++ b/src/test/resources/META-INF/import-from-subdir.less
@@ -1,0 +1,3 @@
+@import "subdir/import-from-root.less";
+
+

--- a/src/test/resources/META-INF/root.less
+++ b/src/test/resources/META-INF/root.less
@@ -1,0 +1,1 @@
+@root-color: #ddd;

--- a/src/test/resources/META-INF/subdir/import-from-root.less
+++ b/src/test/resources/META-INF/subdir/import-from-root.less
@@ -1,0 +1,5 @@
+@import "../root.less";
+
+a{
+  color: @root-color;
+}


### PR DESCRIPTION
Hi, 

I fix a bug when you use @import with subfolders (paths was never used in engine.js, and dirname was used instead)

I added a JUnitTest, with some less files in resources.

Cheers

Romain
