### PR TITLE
Fixed file system resource loader cannot load files from a Windows OS

### DIFF
--- a/src/main/java/com/asual/lesscss/loader/StreamResourceLoader.java
+++ b/src/main/java/com/asual/lesscss/loader/StreamResourceLoader.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
  */
 public abstract class StreamResourceLoader implements ResourceLoader {
 
-	private static final Pattern PATTERN = Pattern.compile("^([\\w]+):(.*)");
+	private static final Pattern PATTERN = Pattern.compile("^([\\w]{2,}):(.*)");
 
 	/**
 	 * Returns the schema name associated with the loader.

--- a/src/main/resources/META-INF/engine.js
+++ b/src/main/resources/META-INF/engine.js
@@ -5,10 +5,7 @@ delete arguments;
 
 var basePath = function(path) {
 	if (path != null) {
-		var i = path.lastIndexOf('/');
-		if(i > 0) {
-			return path.substr(0, i + 1);
-		}
+		return path.replace(/^(.*[\/\\])[^\/\\]*$/, '$1');
 	}
 	return "";
 }


### PR DESCRIPTION
Existing JUnit test `com.asual.lesscss.LessEngineTest` fails on Windows OS because the drive letter (C:\, D:\, etc.) unintentionally matches `StreamResourceLoader.Pattern` causing the file location to be rewritten unnecessarily.

The Pattern has been adjusted which now passes all JUnit tests on a Windows OS. Consequently the `engine.js` has also been updated to correctly handle the Windows OS paths that now pass through it.

These changes are based on [existing issue #33 discussions](https://github.com/asual/lesscss-engine/issues/33).
