### PR TITLE
Add a JNDIResourceLoader

### DIFF
--- a/src/main/java/com/asual/lesscss/LessEngine.java
+++ b/src/main/java/com/asual/lesscss/LessEngine.java
@@ -38,6 +38,7 @@ import com.asual.lesscss.loader.ClasspathResourceLoader;
 import com.asual.lesscss.loader.CssProcessingResourceLoader;
 import com.asual.lesscss.loader.FilesystemResourceLoader;
 import com.asual.lesscss.loader.HTTPResourceLoader;
+import com.asual.lesscss.loader.JNDIResourceLoader;
 import com.asual.lesscss.loader.ResourceLoader;
 import com.asual.lesscss.loader.UnixNewlinesResourceLoader;
 
@@ -68,6 +69,7 @@ public class LessEngine {
 		ResourceLoader resourceLoader = new ChainedResourceLoader(
 				new FilesystemResourceLoader(), new ClasspathResourceLoader(
 						LessEngine.class.getClassLoader()),
+				new JNDIResourceLoader(),
 				new HTTPResourceLoader());
 		if(options.isCss()) {
 			return new CssProcessingResourceLoader(resourceLoader);			

--- a/src/main/java/com/asual/lesscss/loader/JNDIResourceLoader.java
+++ b/src/main/java/com/asual/lesscss/loader/JNDIResourceLoader.java
@@ -1,0 +1,28 @@
+package com.asual.lesscss.loader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+/**
+ * A {@link ResourceLoader} that loads JNDI resources.
+ * 
+ * @author Tim Kingman
+ */
+public class JNDIResourceLoader extends StreamResourceLoader {
+
+	private static final String SCHEMA = "jndi";
+
+	@Override
+	protected String getSchema() {
+		return SCHEMA;
+	}
+
+	@Override
+	protected InputStream openStream(String path) throws IOException {
+		URL url = new URL(SCHEMA + ":" + path);
+		URLConnection conn = url.openConnection();
+		return conn.getInputStream();
+	}
+}


### PR DESCRIPTION
I'm trying to integrate LESS with JAWR 3.3 (using a modified version of eliotsykes/less-css-jawr). JAWR configuration uses servlet-relative paths, which are then passed to ServletContext.getResource() to get a jndi:// URL, which I pass to engine.compile(). When LessEngine gets the jndi URL, no ResourceLoader handles it.

I have a working patch that is just a copy/paste of HTTPResourceLoader with a different schema.
