### PR TITLE
`@import (reference)` doesn't work properly

### DIFF
--- a/src/test/java/com/asual/lesscss/LessEngineTest.java
+++ b/src/test/java/com/asual/lesscss/LessEngineTest.java
@@ -186,6 +186,15 @@ public class LessEngineTest {
 	}
 
 	@Test
+	public void testImportReference() throws LessException, IOException {
+		String expected = ".newlogo {\n"
+			+"  background-image: url(../img/logo.png);\n"
+			+"}\n";
+		String result = engine.compile(getResource("less/import-reference.less"));
+		assertEquals(expected, result);
+	}
+
+	@Test
 	public void testSample() throws LessException, IOException {
 		String expected = ".box {\n  color: #fe33ac;\n"
 				+ "  border-color: #fdcdea;\n}\n.box div {\n"

--- a/src/test/resources/META-INF/less/import-reference.less
+++ b/src/test/resources/META-INF/less/import-reference.less
@@ -1,0 +1,5 @@
+@import (reference) "img";
+
+.newlogo {
+	.logo;
+}


### PR DESCRIPTION
This is a WIP PR, initially showing that `@import (reference)` doesn't work properly. It shouldn't output the contents of the referenced file, only make it available for mixins and variables. This works fine in the same version of the Node module.

I haven't worked out why this is, but I wanted to raise this with the initial code. Additions welcome.
