### PR TITLE
Enabling Rhino Script Debugger breaks the compiler.

### DIFF
--- a/src/main/java/com/asual/lesscss/compiler/RhinoCompiler.java
+++ b/src/main/java/com/asual/lesscss/compiler/RhinoCompiler.java
@@ -49,10 +49,10 @@ public class RhinoCompiler implements LessCompiler {
 		global.init(cx);
 		scope = cx.initStandardObjects(global);
 		cx.evaluateReader(scope, new InputStreamReader(sourceMap
-				.openConnection().getInputStream()), sourceMap.getFile(), 1,
+				.openConnection().getInputStream()), sourceMap.toExternalForm(), 1,
 				null);
 		cx.evaluateReader(scope, new InputStreamReader(env.openConnection()
-				.getInputStream()), env.getFile(), 1, null);
+				.getInputStream()), env.toExternalForm(), 1, null);
 		Scriptable lessEnv = (Scriptable) scope.get("lessenv", scope);
 		lessEnv.put("charset", lessEnv, options.getCharset());
 		lessEnv.put("css", lessEnv, options.isCss());
@@ -68,13 +68,13 @@ public class RhinoCompiler implements LessCompiler {
 			lessEnv.put("paths", lessEnv, nativeArray);
 		}
 		cx.evaluateReader(scope, new InputStreamReader(less
-				.openConnection().getInputStream()), less.getFile(), 1,
+				.openConnection().getInputStream()), less.toExternalForm(), 1,
 				null);
 		cx.evaluateReader(scope, new InputStreamReader(cssmin
-				.openConnection().getInputStream()), cssmin.getFile(), 1,
+				.openConnection().getInputStream()), cssmin.toExternalForm(), 1,
 				null);
 		cx.evaluateReader(scope, new InputStreamReader(engine
-				.openConnection().getInputStream()), engine.getFile(), 1,
+				.openConnection().getInputStream()), engine.toExternalForm(), 1,
 				null);
 		compile = (Function) scope.get("compile", scope);
 		Context.exit();


### PR DESCRIPTION
If Rhino script debugger is enabled in the system, the compilation is broken producing such errors:
Failed to load source from file:/home/bblommers/Servers/alfresco-5.0.0.2-OOTB/tomcat/webapps/share/WEB-INF/lib/lesscss-engine-1.5.0.jar!/META-INF/less.js: java.io.FileNotFoundException: /home/bblommers/Servers/alfresco-5.0.0.2-OOTB/tomcat/webapps/share/WEB-INF/lib/lesscss-engine-1.5.0.jar!/META-INF/less.js (No such file or directory)
The Rhino script processor is targeted to a wrong URL of the JavaScript files (the URL is missing the "jar:" protocol at the beginning) and the debugger can't open the scripts.
This issue was found in Alfresco project: https://issues.alfresco.com/jira/browse/MNT-13802